### PR TITLE
Suckless Farbfeld implementation (encoding/decoding)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.0.0)
+﻿cmake_minimum_required(VERSION 3.0.0)
 
 # edit this to wherever your vcpkg is
-set(VCPKG_DIR ../vcpkg CACHE PATH "path to vcpkg root")
+set(VCPKG_DIR ~/.vcpkg CACHE PATH "path to vcpkg root")
 set(VCPKG_TRIPLET x64-linux CACHE PATH "installed img lib triplet")
 
 set(CMAKE_TOOLCHAIN_FILE ${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake)
@@ -9,6 +9,7 @@ set(CMAKE_TOOLCHAIN_FILE ${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake)
 project(seedimg_full VERSION 1.0 DESCRIPTION "seedimg module based image manipulation library")
 include_directories(${VCPKG_DIR}/installed/${VCPKG_TRIPLET}/include ${CMAKE_SOURCE_DIR})
 
+set(CMAKE_MAKE_PROGRAM make)
 set(CMAKE_CXX_STANDARD 20)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -26,6 +27,7 @@ add_subdirectory(seedimg)
 add_subdirectory(seedimg-jpeg)
 add_subdirectory(seedimg-png)
 add_subdirectory(seedimg-webp)
+add_subdirectory(seedimg-format-farbfeld)
 
 # filter modules
 add_subdirectory(seedimg-filters-core)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,10 +1,11 @@
-set(APP_EXE example)
+﻿set(APP_EXE example)
 
 add_executable(${APP_EXE} main.cpp)
 
 target_link_libraries(${APP_EXE} 
     seedimg-filters-core
     seedimg-autodetect
+    seedimg-format-farbfeld
 )
 
 include_directories(../)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,19 +1,25 @@
-#include <filesystem>
+﻿#include <filesystem>
 #include <iostream>
 
 #include <seedimg-autodetect/seedimg-autodetect.hpp>
 #include <seedimg-filters-core/seedimg-filters-core.hpp>
+
+#include <seedimg-format-farbfeld/farbfeld.hxx>
 
 int main() {
   std::cout << "Current path is " << std::filesystem::current_path()
             << std::endl;
   {
     auto a = seedimg_autodetect_from("violeur.png");
+    // auto a = seedimg::modules::farbfeld::from("boileur.ff");
     if (a != std::nullopt) {
-      seedimg::filters::grayscale(*a, true);
-      seedimg::filters::invert(*a);
-      seedimg::filters::crop(*a, {50, 20}, {250, 183});
-      bool b = seedimg_autodetect_to("bioleur.jpg", *a);
+      // seedimg::filters::grayscale(*a, true);
+      // seedimg::filters::invert(*a);
+      // seedimg::filters::crop(*a, {50, 20}, {250, 183});
+      // seedimg_autodetect_to("bioleur.jpg", *a);
+
+      // seedimg::modules::farbfeld::to("boileur_1.ff", *a);
+      seedimg::modules::farbfeld::to("boileur.ff", *a);
     }
     std::cout << "done" << std::endl;
   }

--- a/seedimg-filters-core/seedimg-filters-core.cpp
+++ b/seedimg-filters-core/seedimg-filters-core.cpp
@@ -1,4 +1,4 @@
-// seedimg-filters-core.cpp : Defines the functions for the static library.
+﻿// seedimg-filters-core.cpp : Defines the functions for the static library.
 //
 
 #include "seedimg-filters-core.hpp"
@@ -21,7 +21,7 @@ void grayscale(std::unique_ptr<seedimg::img> &inp_img,
                bool lightness) noexcept {
   // would rather check once if it's in lightness mode than width*height times.
   if (lightness) {
-    for (auto &row : inp_img->get_data()) {
+    for (auto &row : inp_img->data()) {
       for (auto &pix : row) {
         uint8_t linear = static_cast<uint8_t>((0.2126 * (pix.r / 255.0) +
                                                0.7152 * (pix.g / 255.0) +
@@ -31,7 +31,7 @@ void grayscale(std::unique_ptr<seedimg::img> &inp_img,
       }
     }
   } else {
-    for (auto &row : inp_img->get_data()) {
+    for (auto &row : inp_img->data()) {
       for (auto &pix : row) {
         uint8_t avg = (pix.r + pix.g + pix.b) / 3;
         pix = {avg, avg, avg, pix.a};
@@ -43,7 +43,7 @@ void grayscale(std::unique_ptr<seedimg::img> &inp_img,
 void invert(std::unique_ptr<seedimg::img> &inp_img,
             bool invert_alpha) noexcept {
   if (invert_alpha) {
-    for (auto &row : inp_img->get_data()) {
+    for (auto &row : inp_img->data()) {
       for (auto &pix : row) {
         pix = {
             static_cast<std::uint8_t>(seedimg::img::MAX_PIXEL_VALUE - pix.r),
@@ -53,7 +53,7 @@ void invert(std::unique_ptr<seedimg::img> &inp_img,
       }
     }
   } else {
-    for (auto &row : inp_img->get_data()) {
+    for (auto &row : inp_img->data()) {
       for (auto &pix : row) {
         pix = {static_cast<std::uint8_t>(seedimg::img::MAX_PIXEL_VALUE - pix.r),
                static_cast<std::uint8_t>(seedimg::img::MAX_PIXEL_VALUE - pix.g),
@@ -79,8 +79,8 @@ bool crop(std::unique_ptr<seedimg::img> &inp_img, seedimg::point p1,
   for (std::size_t y = 0; y < (ordered_crop_y.second - ordered_crop_y.first);
        ++y) {
     std::memcpy(
-        cropped_img->get_row(static_cast<uint32_t>(y)).data(),
-        inp_img->get_row(static_cast<uint32_t>(y + ordered_crop_y.first))
+        cropped_img->row(static_cast<uint32_t>(y)).data(),
+        inp_img->row(static_cast<uint32_t>(y + ordered_crop_y.first))
                 .data() +
             (ordered_crop_x.first * sizeof(seedimg::pixel)),
         (ordered_crop_x.second - ordered_crop_x.first) *

--- a/seedimg-format-farbfeld/CMakeLists.txt
+++ b/seedimg-format-farbfeld/CMakeLists.txt
@@ -1,0 +1,2 @@
+﻿add_library(seedimg-format-farbfeld SHARED farbfeld.cxx)
+target_link_libraries(seedimg-format-farbfeld PRIVATE seedimg)

--- a/seedimg-format-farbfeld/farbfeld.cxx
+++ b/seedimg-format-farbfeld/farbfeld.cxx
@@ -1,0 +1,99 @@
+﻿#include "farbfeld.hxx"
+
+#include <fstream>
+
+static std::uint16_t fu16be(uint8_t *cb) {
+    return cb[1] << 8 | cb[0];
+}
+static void tu16be(std::uint8_t* out, std::uint16_t n) {
+    out[0] = n >> 8 & 0xff;
+    out[1] = n & 0xff;
+}
+static std::uint32_t fu32be(uint8_t *cb) {
+    return cb[0] << 24 | cb[1] << 16 | cb[2] << 8 | cb[3];
+}
+static std::uint8_t* tu32be(std::uint32_t n) {
+    auto out = (uint8_t*)malloc(4);
+    out[0] = (n >> 24) & 0xff;
+    out[1] = (n >> 16) & 0xff;
+    out[2] = (n >> 8) & 0xff;
+    out[3] = n & 0xff;
+    return out;
+}
+
+// https://stackoverflow.com/a/41762509/10978642
+static std::uint8_t b16_8(std::uint16_t n) { return n >> 8; }
+// https://stackoverflow.com/a/6436100/10978642
+// NOTE: simple bitshifting could've solved but would
+//       be quite noisy, so an addition put.
+static std::uint16_t b8_16(std::uint8_t n) { return (n << 8) + n; }
+
+namespace seedimg::modules::farbfeld {
+bool check(const std::string& filename) noexcept {
+    std::ifstream input(filename);
+    char sig[8];
+
+    try { input.read(sig, 8); }
+    catch(std::iostream::failure) { return false; }
+    return std::memcmp(sig, "farbfeld", 8) == 0;
+}
+
+std::optional<std::unique_ptr<seedimg::img>> from(const std::string& filename) noexcept {
+    std::ifstream input(filename);
+    struct {
+        char sig[8];
+        uint8_t width[4];
+        uint8_t height[4];
+    } rawinfo;
+
+    try {
+        input.read(rawinfo.sig, 8)
+             .read(reinterpret_cast<char*>(rawinfo.width), 4)
+             .read(reinterpret_cast<char*>(rawinfo.height), 4);
+    } catch(std::ios_base::failure) { return std::nullopt; }
+
+    // siganture match is mandatory else invalid Farbfeld file.
+    if(std::memcmp(rawinfo.sig, "farbfeld", 8) != 0)
+        return std::nullopt;
+
+    auto result = std::make_unique<seedimg::img>(fu32be(rawinfo.width), fu32be(rawinfo.height));
+
+    uint8_t rawpixel[8];
+    for(std::uint32_t y = 0; y < result->height; ++y) {
+        for(std::uint32_t x = 0; x < result->width; ++x ) {
+            try { input.read(reinterpret_cast<char*>(rawpixel), 8); }
+            catch(std::ios_base::failure) { return std::nullopt; }
+
+            result->pixel(x,y) = {b16_8(fu16be(rawpixel)),     b16_8(fu16be((rawpixel+2))),
+                                  b16_8(fu16be((rawpixel+4))), b16_8(fu16be((rawpixel+6)))};
+        }
+    }
+
+    return result;
+}
+
+bool to(const std::string& filename, const std::unique_ptr<seedimg::img>& image) noexcept {
+    std::ofstream output(filename);
+
+    try {
+        output.write("farbfeld", 8)
+              .write(reinterpret_cast<char*>(tu32be(image->width)), 4)
+              .write(reinterpret_cast<char*>(tu32be(image->height)), 4);
+    } catch (std::ios_base::failure) { return false; }
+
+    uint8_t rawpixel[8];
+    for(std::uint32_t y = 0; y < image->height; ++y) {
+        for(std::uint32_t x = 0; x < image->width; ++x ) {
+            auto px = image->pixel(x, y);
+
+            tu16be(rawpixel, b8_16(px.r)); tu16be(rawpixel+2, b8_16(px.g));
+            tu16be(rawpixel, b8_16(px.b)); tu16be(rawpixel+6, b8_16(px.a));
+
+            try { output.write(reinterpret_cast<char*>(rawpixel), 8); }
+            catch(std::ios_base::failure) { return false; }
+        }
+    }
+
+    return true;
+}
+}

--- a/seedimg-format-farbfeld/farbfeld.hxx
+++ b/seedimg-format-farbfeld/farbfeld.hxx
@@ -1,0 +1,14 @@
+﻿#ifndef FARBFELD_HXX
+#define FARBFELD_HXX
+
+#include <seedimg/seedimg.hpp>
+
+namespace seedimg::modules {
+namespace farbfeld {
+bool check(const std::string& filename) noexcept;
+std::optional<std::unique_ptr<seedimg::img>> from(const std::string& filename) noexcept;
+bool to(const std::string& filename, const std::unique_ptr<seedimg::img>& image) noexcept;
+}
+}
+
+#endif // FARBFELD_HXX

--- a/seedimg-jpeg/seedimg-jpeg.cpp
+++ b/seedimg-jpeg/seedimg-jpeg.cpp
@@ -1,4 +1,4 @@
-// seedimg-jpeg.cpp : Defines the functions for the static library.
+﻿// seedimg-jpeg.cpp : Defines the functions for the static library.
 //
 
 #include <csetjmp>
@@ -84,9 +84,9 @@ seedimg::modules::jpeg::from(const std::string &filename) noexcept {
       return std::nullopt;
 
     for (std::size_t x = 0; x < res_img->width; ++x) {
-#define P(ch) rowbuffer[3 * x + ch]
-      res_img->get_pixel(static_cast<uint32_t>(x),
-                         static_cast<uint32_t>(y)) = {P(0), P(1), P(2), 0xFF};
+      #define P(ch) rowbuffer[3 * x + ch]
+      res_img->pixel({static_cast<uint32_t>(x),
+                      static_cast<uint32_t>(y)}) = {P(0), P(1), P(2), 0xFF};
     }
   }
 
@@ -151,8 +151,8 @@ bool seedimg::modules::jpeg::to(const std::string &filename,
   for (std::size_t y = 0; y < image->height; ++y) {
     for (std::size_t x = 0; x < image->width; ++x) {
 #define P(ch) rowbuffer[3 * x + ch]
-      auto pix =
-          image->get_pixel(static_cast<uint32_t>(x), static_cast<uint32_t>(y));
+      auto pix = image->pixel({static_cast<uint32_t>(x),
+                               static_cast<uint32_t>(y)});
       P(0) = pix.r;
       P(1) = pix.g;
       P(2) = pix.b;

--- a/seedimg-png/seedimg-png.cpp
+++ b/seedimg-png/seedimg-png.cpp
@@ -1,4 +1,4 @@
-// seedimg-png.cpp : Defines the functions for the static library.
+﻿// seedimg-png.cpp : Defines the functions for the static library.
 //
 
 #include <filesystem>
@@ -120,7 +120,7 @@ seedimg::modules::png::from(const std::string &filename) noexcept {
     for (std::size_t y = 0; y < res_img->height; ++y) {
       png_read_row(png_ptr,
                    reinterpret_cast<png_bytep>(
-                       res_img->get_row(static_cast<uint32_t>(y)).data()),
+                       res_img->row(static_cast<uint32_t>(y)).data()),
                    nullptr);
     }
   } else {
@@ -134,9 +134,8 @@ seedimg::modules::png::from(const std::string &filename) noexcept {
       png_bytep row = row_pointers[y];
       for (std::size_t x = 0; x < res_img->width; ++x) {
         png_bytep px = &(row[x * 4]);
-        res_img->get_pixel(static_cast<uint32_t>(x),
-                           static_cast<uint32_t>(y)) = {px[0], px[1], px[2],
-                                                        px[3]};
+        res_img->pixel({static_cast<uint32_t>(x),
+                        static_cast<uint32_t>(y)}) = {px[0], px[1], px[2], px[3]};
       }
       free(row);
     }
@@ -154,7 +153,7 @@ finalise:
   if (errcode != 0 || res_img == nullptr) {
     return std::nullopt;
   } else {
-    return std::move(res_img);
+    return res_img;
   }
 }
 
@@ -209,7 +208,7 @@ bool seedimg::modules::png::to(
   for (std::size_t y = 0; y < inp_img->height; ++y) {
     png_write_row(png_ptr,
                   reinterpret_cast<png_bytep>(
-                      inp_img->get_row(static_cast<uint32_t>(y)).data()));
+                      inp_img->row(static_cast<uint32_t>(y)).data()));
   }
 
   png_write_end(png_ptr, nullptr);

--- a/seedimg-webp/seedimg-webp.cpp
+++ b/seedimg-webp/seedimg-webp.cpp
@@ -1,4 +1,4 @@
-// seedimg-webp.cpp : Defines the functions for the static library.
+﻿// seedimg-webp.cpp : Defines the functions for the static library.
 //
 
 #include <filesystem>
@@ -36,7 +36,7 @@ bool seedimg::modules::webp::to(const std::string &filename,
       new uint8_t[inp_img->height * inp_img->width * sizeof(seedimg::pixel)];
   for (size_t y = 0; y < inp_img->height; y++) {
     std::memcpy(data + y * inp_img->width * sizeof(seedimg::pixel),
-                inp_img->get_row(static_cast<std::uint32_t>(y)).data(),
+                inp_img->row(static_cast<std::uint32_t>(y)).data(),
                 inp_img->width * sizeof(seedimg::pixel));
   }
   // this is the amount of bytes output has been allocated, 0 if failure
@@ -74,11 +74,11 @@ seedimg::modules::webp::from(const std::string &filename) noexcept {
   auto res_img = std::make_unique<seedimg::img>(width, height);
   uint8_t *inp_img = WebPDecodeRGBA(data.get(), size, &width, &height);
   for (size_t y = 0; y < static_cast<size_t>(height); y++) {
-    std::memcpy(res_img->get_row(static_cast<std::uint32_t>(y)).data(),
+    std::memcpy(res_img->row(static_cast<std::uint32_t>(y)).data(),
                 inp_img + y * static_cast<unsigned long>(width) *
                               sizeof(seedimg::pixel),
                 static_cast<unsigned long>(width) * sizeof(seedimg::pixel));
   }
   WebPFree(inp_img);
-  return std::move(res_img);
+  return res_img;
 }

--- a/seedimg-webp/seedimg-webp.hpp
+++ b/seedimg-webp/seedimg-webp.hpp
@@ -1,4 +1,4 @@
-#ifndef _SEEDIMG_WEBP_H
+﻿#ifndef _SEEDIMG_WEBP_H
 #define _SEEDIMG_WEBP_H
 
 #include <memory>
@@ -8,10 +8,13 @@
 namespace seedimg::modules {
 namespace webp {
 bool check(const std::string &filename) noexcept;
-bool to(const std::string &filename, std::unique_ptr<seedimg::img> &inp_img,
-        float quality = 100.0) noexcept;
+bool to(const std::string &filename, std::unique_ptr<seedimg::img> &inp_img, float quality = 100.0) noexcept;
 std::optional<std::unique_ptr<seedimg::img>>
 from(const std::string &filename) noexcept;
+
+namespace animated {
+std::unique_ptr<std::vector<seedimg::img>> from(const std::string& filename) noexcept;
+}
 } // namespace webp
 } // namespace seedimg::modules
 

--- a/seedimg/seedimg.cpp
+++ b/seedimg/seedimg.cpp
@@ -1,4 +1,4 @@
-// seedimg.cpp : Defines the functions for the static library.
+﻿// seedimg.cpp : Defines the functions for the static library.
 //
 
 #include <filesystem>
@@ -32,7 +32,7 @@ seedimg::from(const std::string &filename) noexcept {
   const auto stride = sizeof(seedimg::pixel) * image->width;
 
   for (std::size_t y = 0; y < image->height; ++y)
-    infile.read(reinterpret_cast<char *>(image->get_row(y).data()),
+    infile.read(reinterpret_cast<char *>(image->row(y).data()),
                 static_cast<long>(stride));
 
   return std::optional<decltype(image)>();
@@ -52,7 +52,7 @@ bool seedimg::to(const std::string &filename,
   const auto stride = sizeof(seedimg::pixel) * image->width;
 
   for (std::size_t y = 0; y < image->height; ++y)
-    outfile.write(reinterpret_cast<const char *>(image->get_row(y).data()),
+    outfile.write(reinterpret_cast<const char *>(image->row(y).data()),
                   static_cast<long>(stride));
 
   return true;

--- a/seedimg/seedimg.hpp
+++ b/seedimg/seedimg.hpp
@@ -1,72 +1,101 @@
-#ifndef _SEEDIMG_CORE_H
+﻿#ifndef _SEEDIMG_CORE_H
 #define _SEEDIMG_CORE_H
 
 #include <cinttypes>
-#include <cstring> // just for memset '-'
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 namespace seedimg {
-
+/**
+ * Represents a point in a 2D dimensional space, having two axes:
+ * horizontal and vertical (.first = horizontal, .second = vertical).
+ */
 typedef std::pair<std::uint32_t, std::uint32_t> point;
 
+/**
+ * A version of std::vector that is fixed to its original size since its construction.
+ * This is a workaround as std::vector propogates const everywhere.
+ */
 template <typename T> class vector_fixed {
 public:
-  vector_fixed(std::size_t l = 0) : vec_(l) {}
-  vector_fixed(std::size_t l, T elem) : vec_(l, elem) {}
-  std::size_t size(void) const noexcept { return vec_.size(); }
+  vector_fixed(std::size_t size = 0)     : buffer(size) {}
+  vector_fixed(std::size_t size, T elem) : buffer(size, elem) {}
 
-  T &operator[](std::size_t e) { return vec_[e]; }
-  T *data(void) { return vec_.data(); }
-  auto begin() { return vec_.begin(); }
-  auto end() { return vec_.end(); }
+  std::size_t size() const noexcept { return buffer.size();  }
+  T &operator[](std::size_t index)  { return buffer[index];  }
+  T *data()                         { return buffer.data();  }
+
+  auto begin()                      { return buffer.begin(); }
+  auto end()                        { return buffer.end();   }
 
 protected:
-  std::vector<T> vec_;
+  std::vector<T> buffer;
 };
 
+/**
+ * A pixel is an element which is a essential building block of an image.
+ * This is in RGBA colorspace with unsigned 8-bit precision.
+ */
 struct pixel {
-  std::uint8_t r;
-  std::uint8_t g;
-  std::uint8_t b;
-  std::uint8_t a;
-  bool operator==(const pixel &other) const noexcept {
-    return std::tie(r, g, b, a) == std::tie(other.r, other.g, other.b, other.a);
+  std::uint8_t r,g,b,a;
+  bool operator==(const pixel &o) const noexcept {
+    return std::tie(r,g,b,a) == std::tie(o.r,o.g,o.b,o.a);
   }
 };
 
+/**
+ * A fixed size 2D plane that is made out of seedimg::pixel (aka. RGBA pixels)
+ * which all the seedimg libraries use as their core mechanism.
+ */
 class img {
 public:
-  static constexpr std::uint8_t MAX_PIXEL_VALUE = UINT8_MAX;
-  std::uint32_t const width;
-  std::uint32_t const height;
-  img(std::uint32_t w = 0, std::uint32_t h = 0) noexcept
-      : width(w), height(h), data(h, seedimg::vector_fixed<seedimg::pixel>(w)) {
-    for (auto &row : data)
-      std::memset(row.data(), 0, sizeof(seedimg::pixel) * row.size());
-  }
-  seedimg::pixel &get_pixel(std::uint32_t x, std::uint32_t y) {
-    return data[y][x];
-  }
-  auto &get_row(std::uint32_t y) { return data[y]; }
-  auto &get_data(void) { return data; }
+    // stupid compiler errors, don't know why it's here, ask multi#3304.
+    static constexpr std::uint8_t MAX_PIXEL_VALUE = UINT8_MAX;
+
+    const uint32_t width;
+    const uint32_t height;
+
+    img(std::uint32_t w = 0, std::uint32_t h = 0) noexcept :
+        width(w), height(h), buffer(h, vector_fixed<seedimg::pixel>(w)) {
+        const auto stride = sizeof(seedimg::pixel) * w;
+        for (auto &row: buffer)
+            std::memset(row.data(), 0, stride);
+    }
+
+    auto &row(std::uint32_t row)                  { return buffer[row];               }
+    auto &pixel(point p)                          { return buffer[p.second][p.first]; }
+    auto &pixel(std::uint32_t x, std::uint32_t y) { return buffer[y][x];              }
+    auto &data()                                  { return buffer;                    }
 
 private:
-  // stored in row major order
-  // width amount of pixels in a row
-  // height amount of rows.
-  seedimg::vector_fixed<seedimg::vector_fixed<seedimg::pixel>> data;
+    /**
+     * Underlying buffer that'd be used for holding image data.
+     *
+     * Pixels are stored in row-major order and stack by
+     * top-to-bottom order.
+     */
+    vector_fixed<vector_fixed<seedimg::pixel>> buffer;
 };
 
-bool to(const std::string &filename,
-        std::unique_ptr<seedimg::img> &inp_img) noexcept;
-std::optional<std::unique_ptr<seedimg::img>>
-from(const std::string &filename) noexcept;
+// Raw-dump loading/doing functions, non-interchangable between systems.
+// Because of the differences in endianness.
+
+/**
+ * @brief Does a raw-dump of the image, can be loaded back using from().
+ */
+bool to(const std::string &filename, std::unique_ptr<img> &image) noexcept;
+
+/**
+ * @brief Loads a raw-dump of the image, this exists only for debugging purposes.
+ *        No gurantees of portability is expressed or implied.
+ */
+std::optional<std::unique_ptr<img>> from(const std::string &filename) noexcept;
 
 namespace modules {};
 namespace filters {};
-} // namespace seedimg
+}
 
 #endif


### PR DESCRIPTION
- Has breaking changes in the core conventions of this library, to adhere C++ STL naming conventions.
- Adoption of the Suckless Farbfeld format, similar to its rawdump format (for debugging) but standardized.
  Only Suckless imaging tools and some other imaging libraries (e.g. `image-rs`) are known to use this.